### PR TITLE
Aim_up_correction.

### DIFF
--- a/Assets/Scripts/Player/PlayerShoot.cs
+++ b/Assets/Scripts/Player/PlayerShoot.cs
@@ -67,6 +67,8 @@ public class PlayerShoot : MonoBehaviour
 
     void Update()
     {
+
+        Debug.Log(shootPoint.localRotation);
         if(!PauseMenu.isPaused)
         {
             if (Time.time >= nextShoot)
@@ -147,9 +149,10 @@ public class PlayerShoot : MonoBehaviour
         if(pointingUP == true)
         {
             yield return null;
+
         } else
         {
-            shootPoint.Rotate(0f, 0f, 90f);
+            shootPoint.localRotation = Quaternion.Euler(0f, 0f, 90f);
             shootPoint.localPosition = new Vector3(-0.056f, 0.384f, 0);
             pointingUP = true;
             yield return null;
@@ -161,7 +164,7 @@ public class PlayerShoot : MonoBehaviour
     {
         if (pointingUP == true)
         {
-            shootPoint.Rotate(0f, 0f, -90f);
+            shootPoint.localRotation = Quaternion.Euler(0f, 0f, 0f);
             shootPoint.localPosition = new Vector3(0.265f, 0.144f, 0);
             pointingUP = false;
         }
@@ -171,7 +174,7 @@ public class PlayerShoot : MonoBehaviour
     public void ChangeAimPositionUp()
     {
 
-        shootPoint.Rotate(0f, 0f, 90f);
+        shootPoint.localRotation = Quaternion.Euler(0f, 0f, 90f);
         shootPoint.localPosition = new Vector3(-0.056f, 0.384f, 0);
         pointingUP = true;
         
@@ -181,7 +184,7 @@ public class PlayerShoot : MonoBehaviour
     {
         if (pointingUP == true)
         {
-            shootPoint.Rotate(0f, 0f, -90f);
+            shootPoint.localRotation = Quaternion.Euler(0f, 0f, 0f);
             shootPoint.localPosition = new Vector3(0.265f, 0.144f, 0);
             pointingUP = false;
         }


### PR DESCRIPTION
ao invés de Rotacionar a mira ao mirar pra cima eu passar a SETAR uma nova rotação, e seto ela de novo ao parar de mirar pra cima. Antes ele tava somando 90 grau e subtraindo ao parar de mirar, ai ao clicar muito rápido dava uns bug de as vezes somar duas vezes  90 subtrair mais de uma vez 90 e ficava esse comportamento maluco