### PR TITLE
level_design_redo

### DIFF
--- a/Assets/Prefabs/Shoot/projeti_chinelo.prefab
+++ b/Assets/Prefabs/Shoot/projeti_chinelo.prefab
@@ -31,7 +31,7 @@ Transform:
   m_GameObject: {fileID: 3149752523426650186}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -7.19, y: 3.03, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 1}
+  m_LocalScale: {x: 2.7, y: 2.7, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}


### PR DESCRIPTION
+ Nível mais plano e com menos buracos.
+ Sprite de Arma no nível com efeito animação de brilho pra chamar mais atenção.
- Reduzi um pouco o tamanho do projetil de chinelo.
- Reduzi um pouco a altura da camera e aumentei o deadzone pra camera nao mexer tanto ao pular.